### PR TITLE
#1 - Modified library for use in other Node modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install globally:
 To install to your local folder:
 `npm install node-tnef`
 
-# How to Use
+# How to Use as a Console application
 Run: `node-tnef --help` for a condensed outline of how to use the command line application
 
 `node-tnef` can parse entire directories or just single files.
@@ -27,6 +27,33 @@ If you are attempting to parse just a single file, find the file that is the sup
 `node-tnef parse -f <path to your TNEF file>` or `node-tnef parse --file <path to your TNEF file>`
 
 The TNEF parser will enumerate every file in the directory. If the file does not contain the TNEF signature, it will output to the console and move to the next file. If the file contains the TNEF signature, the parser will extract the attachment contents and write them to the new folder `<path to your TNEF files>/processed`.
+
+# How to use within a NodeJS project
+Just require in `node-tnef` into a NodeJS project. The `node-tnef` library currently has a `parse` method that:
+- takes a path to a TNEF formatted file
+- a callback function which returns an error object and an object containing all attachments within the provided file(or null if none)
+
+The format of the content object returned is an Array Object. Can be null
+
+Object Properties:
+- Title - The attachment's title(including file extension)
+- Data - The attachment data. Can be used to write to a file using `fs` or another mechanism. Create a new Buffer passing in Data.
+
+Example:
+```
+var tnef = require('node-tnef')
+var fs = require('fs')
+var path = require('path')
+
+tnef.parse('/path/to/the/tnef/file', function (err, content) {
+    // here you could write the data to a file for example
+    var firstAttachment = content[0]
+    fs.writeFile(path.join(aPath, firstAttachment.Title), new Buffer(firstAttachment.Data), (err) => {
+        console.log('success!')
+    })
+    ...
+})
+```
 
 # Issues/Feedback?
 Create an issue at this repo and I will try my best to fix the problem or implement the suggestion.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       ]
     ]
   },
-  "main": "dist/index.js",
+  "main": "dist/commands/parse.js",
   "bin": {
     "node-tnef": "dist/bin/node-tnef.js"
   },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
+    "bunyan": "^1.8.12",
     "convert-string": "^0.1.0",
     "yargs": "^10.0.3"
   }

--- a/src/commands/parse.js
+++ b/src/commands/parse.js
@@ -84,6 +84,20 @@ export function handler(argv) {
     }
 }
 
+/**
+ * This callback type is called `parseCallback` and is displayed as a global symbol.
+ *
+ * @callback parseCallback
+ * @param {Object[]} Attachments - Array of TNEF attachments
+ */
+
+/**
+ * parse a single
+ * TNEF file given the file path and a callback
+ * @param {string} filePath - The path to the TNEF file
+ * @param {parseCallback} callback - The callback
+ *  
+ */
 // method that can be used within another Node module to parse a single
 // TNEF file given the file path and a callback
 export function parse(filePath, callback) {
@@ -267,7 +281,7 @@ var ProcessFile = ((file, directory) => {
         if (!fs.existsSync(processedPath)) {
             fs.mkdirSync(processedPath)
         }
-
+        
         log.info('ATTEMPTING TO PARSE ' + fullPath);
 
         DecodeFile(fullPath).then((result) => {

--- a/src/commands/parse.js
+++ b/src/commands/parse.js
@@ -84,6 +84,26 @@ export function handler(argv) {
     }
 }
 
+// method that can be used within another Node module to parse a single
+// TNEF file given the file path and a callback
+export function parse(filePath, callback) {
+    log.info('ATTEMPTING TO PARSE ' + filePath);
+
+    DecodeFile(filePath).then((result) => {
+        // if there is an attachment, extract it and save to file
+        if (result && result.Attachments && result.Attachments.length > 0) {
+            log.info('Done decoding ' + filePath + '!!')
+            callback(false, result.Attachments)
+        } else {
+            log.warn('Something went wrong with parsing ' + filePath + '. Make sure this is a TNEF file. If you are certain it is, possibly the file is corrupt')
+            callback(true, null)
+        }
+    }).catch((err) => {
+        log.error('Something went wrong parsing ' + filePath, err)
+        callback(true, err)
+    })
+}
+
 function parseOptions(argv) {
     if (!argv) {
         throw new Error('No arguments provided!')


### PR DESCRIPTION
The primary ask of this issue was to enhance node-tnef such that it could be used within other Node modules/projects. The original goal behind node-tnef was just to make it as a console/command line application that could be used via Terminal or Command Line. The following things have been achieved:

- Use a more powerful logging library(went with Bunyan) rather than `console.log`, `console.error`
- Allow the ability to `require` `node-tnef` into other Node projects with a `parse` method that will return an array of Attachment objects containing the attachment title and actual data.
- Updated the Readme accordingly