### PR TITLE
Fix parseBuffer callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-tnef",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "TNEF Parser using NodeJS",
   "babel": {
     "presets": [

--- a/src/commands/parse.js
+++ b/src/commands/parse.js
@@ -124,7 +124,12 @@ export function parse(filePath, callback) {
 export function parseBuffer(data, callback) {
     var arr = [...data]
 
-    callback(true, Decode(arr))
+    try {
+        const decodedResult = Decode(arr)
+        callback(decodedResult ? true : false, decodedResult)
+    } catch (err) {
+        callback(false, err)
+    }
 }
 
 function parseOptions(argv) {


### PR DESCRIPTION
Refactor the `parseBuffer` so that consumers wanting to promisify the method can do so.